### PR TITLE
fix: benchmark 函数中解决i32 溢出

### DIFF
--- a/tutorial/10_trait_objects.md
+++ b/tutorial/10_trait_objects.md
@@ -399,22 +399,40 @@ fn benchmark() {
     
     // 动态分发的开销
     let start = Instant::now();
-    let mut sum = 0;
+    let mut sum: i32 = 0;
     for _ in 0..1000000 {
         for computer in &computers {
             sum += computer.compute(10);
         }
     }
     println!("动态分发时间: {:?}", start.elapsed());
+    println!("动态分发结果 (i32): {}", sum);
     
     // 静态分发对比
     let adder = Adder(5);
     let start = Instant::now();
-    let mut sum = 0;
+    let mut sum: i64 = 0;
     for _ in 0..1000000 {
-        sum += adder.compute(10);
+        sum += adder.compute(10); // 隐式转换 i32 到 i64
     }
     println!("静态分发时间: {:?}", start.elapsed());
+    println!("静态分发结果 (i32): {}", sum);
+
+    // 动态分发大循环 (i64)，验证无溢出
+    let computers: Vec<Box<dyn Compute>> = vec![Box::new(Multiplier(100))];
+    let start = Instant::now();
+    let mut sum: i64 = 0;
+    for _ in 0..100_000_000 {
+        for computer in &computers {
+            sum += computer.compute(1000) as i64; // 显式转换以匹配 i64
+        }
+    }
+    println!("动态分发大循环时间 (i64): {:?}", start.elapsed());
+    println!("动态分发大循环结果 (i64): {}", sum);
+}
+
+fn main() {
+    benchmark();
 }
 ```
 
@@ -590,4 +608,4 @@ impl ServiceManager {
    - O：通过 `Box<dyn Trait>` 获得所有权
    - 特征对象遵循与普通引用相同的借用规则
 
-特征对象是 Rust 中实现运行时多态的重要机制，虽然有一定的性能开销，但在需要处理异构集合时非常有用。下一章我们将学习 Rust 标准库中的常用特征。 
+特征对象是 Rust 中实现运行时多态的重要机制，虽然有一定的性能开销，但在需要处理异构集合时非常有用。下一章我们将学习 Rust 标准库中的常用特征。


### PR DESCRIPTION
# 测试验证
```rust
use std::time::Instant;

trait Compute {
    fn compute(&self, x: i32) -> i32;
}

struct Adder(i32);
impl Compute for Adder {
    fn compute(&self, x: i32) -> i32 {
        x + self.0
    }
}

struct Multiplier(i32);
impl Compute for Multiplier {
    fn compute(&self, x: i32) -> i32 {
        x * self.0
    }
}

fn benchmark() {
    let computers: Vec<Box<dyn Compute>> = vec![
        Box::new(Adder(5)),
        Box::new(Multiplier(3)),
        Box::new(Adder(10)),
    ];

    // 动态分发的开销
    let start = Instant::now();
    let mut sum = 0;
    for _ in 0..1000000 {
        for computer in &computers {
            sum += computer.compute(10);
        }
    }
    println!("动态分发时间: {:?}", start.elapsed());
    println!("动态分发结果: {}", sum); // 添加输出

    // 静态分发对比
    let adder = Adder(5);
    let start = Instant::now();
    let mut sum = 0;
    for _ in 0..1000000 {
        sum += adder.compute(10);
    }
    println!("静态分发时间: {:?}", start.elapsed());
    println!("静态分发结果: {}", sum); // 添加输出
}

fn main() {
    benchmark();

    // 溢出测试 1：接近溢出边界
    let computers: Vec<Box<dyn Compute>> = vec![Box::new(Multiplier(100))];
    let start = Instant::now();
    let mut sum: i32 = 0;
    let mut iteration = 0;
    let result = (|| -> Result<(), &'static str> {
        for i in 0..21_500 {
            for computer in &computers {
                sum = sum.checked_add(computer.compute(1000)).ok_or("溢出发生")?;
            }
            iteration = i + 1;
        }
        Ok(())
    })();

    println!("溢出测试时间 1: {:?}", start.elapsed());
    match result {
        Ok(()) => println!("溢出测试结果: {}", sum),
        Err(e) => println!(
            "溢出测试错误: {}, sum: {}, 在第 {} 次循环",
            e, sum, iteration
        ),
    }

    // 溢出测试 2：大循环，检查溢出
    let computers: Vec<Box<dyn Compute>> = vec![Box::new(Multiplier(100))];
    let start = Instant::now();
    let mut sum: i32 = 0;
    let mut iteration = 0;
    let result = (|| -> Result<(), &'static str> {
        for i in 0..100_000_000 {
            for computer in &computers {
                sum = sum.checked_add(computer.compute(1000)).ok_or("溢出发生")?;
            }
            iteration = i + 1;
        }
        Ok(())
    })();
    println!("溢出测试时间 2: {:?}", start.elapsed());
    match result {
        Ok(()) => println!("溢出测试结果: {}", sum),
        Err(e) => println!(
            "溢出测试错误: {}, sum: {}, 在第 {} 次循环",
            e, sum, iteration
        ),
    }
}

#[cfg(test)]
mod tests {
    use super::*;

    #[test]
    fn test_overflow() {
        let computers: Vec<Box<dyn Compute>> = vec![Box::new(Multiplier(100))];
        let mut sum: i32 = 0;
        let result = (|| -> Result<(), &'static str> {
            for _ in 0..100_000_000 {
                for computer in &computers {
                    sum = sum.checked_add(computer.compute(1000)).ok_or("溢出发生")?;
                }
            }
            Ok(())
        })();
        assert!(result.is_err(), "预期溢出");
    }

    #[test]
    fn test_no_overflow_with_i64() {
        let computers: Vec<Box<dyn Compute>> = vec![Box::new(Multiplier(100))];
        let mut sum: i64 = 0;
        for _ in 0..100_000_000 {
            for computer in &computers {
                sum += computer.compute(1000) as i64;
            }
        }
        assert_eq!(sum, 10_000_000_000_000);
    }

    #[test]
    fn test_near_overflow() {
        let computers: Vec<Box<dyn Compute>> = vec![Box::new(Multiplier(100))];
        let mut sum: i32 = 0;
        for _ in 0..21_474 {
            for computer in &computers {
                sum += computer.compute(1000);
            }
        }
        assert!(sum <= i32::MAX, "未达到溢出");
    }

    #[test]
    #[should_panic]
    fn test_overflow_without_checked_add() {
        let computers: Vec<Box<dyn Compute>> = vec![Box::new(Multiplier(100))];
        let mut sum: i32 = 0;
        for _ in 0..100_000_000 {
            for computer in &computers {
                sum += computer.compute(1000);
            }
        }
        assert!(sum <= i32::MAX, "未达到溢出");
        println!("sum: {}", sum);
    }
}

```
## 输出
```bash
rust-ecosystem-learning on  main [?] is 📦 0.1.0 via 🦀 1.88.0 on 🐳 v28.2.2 (orbstack) took 2.5s 
➜ cargo run --example trait2 
   Compiling rust-ecosystem-learning v0.1.0 (/Users/qiaopengjun/Code/Rust/rust-ecosystem-learning)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.10s
     Running `target/debug/examples/trait2`
动态分发时间: 42.546541ms
动态分发结果: 65000000
静态分发时间: 5.868084ms
静态分发结果: 15000000
溢出测试时间 1: 613.292µs
溢出测试错误: 溢出发生, sum: 2147400000, 在第 21474 次循环
溢出测试时间 2: 481.125µs
溢出测试错误: 溢出发生, sum: 2147400000, 在第 21474 次循环

rust-ecosystem-learning on  main [?] is 📦 0.1.0 via 🦀 1.88.0 on 🐳 v28.2.2 (orbstack) 
➜ cargo test --example trait2
   Compiling rust-ecosystem-learning v0.1.0 (/Users/qiaopengjun/Code/Rust/rust-ecosystem-learning)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.30s
     Running unittests examples/trait2.rs (target/debug/examples/trait2-ae6d12b7ff9c966e)

running 4 tests
test tests::test_near_overflow ... ok
test tests::test_overflow ... ok
test tests::test_overflow_without_checked_add - should panic ... ok
test tests::test_no_overflow_with_i64 ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.79s

```

通过 cargo run --example trait2 和 cargo test --example trait2 的运行结果，成功证明了 i32 溢出问题。main 函数中的溢出测试 1（21,500 次循环，计算 100,000 * 21,500 = 2,150,000,000）和测试 2（100,000,000 次循环，计算 100,000 * 100,000,000 = 10,000,000,000,000）使用 checked_add 捕获溢出，精确记录溢出点（第 21,474 次循环，sum = 2,147,400,000），验证了 i32 最大值 2,147,483,647 的限制。单元测试进一步通过 test_overflow（验证溢出）、test_no_overflow_with_i64（验证 i64 正确性）、test_near_overflow（验证接近边界的正确性）和 test_overflow_without_checked_add（验证调试模式下 panic），全面展示了 i32 溢出的发生和检测。

解决： 变量从 i32 改为 i64，并添加了结果输出，添加 i64 大循环测试以展示 i64 在高循环场景下不溢出，增强与 main 中 i32 溢出测试的对比

